### PR TITLE
Add backend skeleton for shop generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,36 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <!-- JWT library for token generation and validation -->
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.12.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.12.3</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.12.3</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <!-- PayPal Java SDK for payment integration -->
+                <dependency>
+                        <groupId>com.paypal.sdk</groupId>
+                        <artifactId>paypal-rest-sdk</artifactId>
+                        <version>1.14.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/app/mydevbro/backend/controller/AuthController.java
+++ b/src/main/java/app/mydevbro/backend/controller/AuthController.java
@@ -1,0 +1,49 @@
+package app.mydevbro.backend.controller;
+
+import app.mydevbro.backend.entity.User;
+import app.mydevbro.backend.security.JwtUtil;
+import app.mydevbro.backend.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(AuthenticationManager authenticationManager,
+                          UserService userService,
+                          JwtUtil jwtUtil) {
+        this.authenticationManager = authenticationManager;
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@Valid @RequestBody User user) {
+        return ResponseEntity.ok(userService.register(user));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestParam String email,
+                                        @RequestParam String password) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(email, password));
+            if (authentication.isAuthenticated()) {
+                return ResponseEntity.ok(jwtUtil.generateToken(email));
+            }
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.status(401).build();
+    }
+}

--- a/src/main/java/app/mydevbro/backend/controller/DownloadController.java
+++ b/src/main/java/app/mydevbro/backend/controller/DownloadController.java
@@ -1,0 +1,36 @@
+package app.mydevbro.backend.controller;
+
+import app.mydevbro.backend.entity.ShopProject;
+import app.mydevbro.backend.service.CodeGenerationService;
+import app.mydevbro.backend.service.ShopProjectService;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+
+@RestController
+@RequestMapping("/api/download")
+public class DownloadController {
+
+    private final ShopProjectService shopProjectService;
+    private final CodeGenerationService codeGenerationService;
+
+    public DownloadController(ShopProjectService shopProjectService,
+                              CodeGenerationService codeGenerationService) {
+        this.shopProjectService = shopProjectService;
+        this.codeGenerationService = codeGenerationService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FileSystemResource> download(@PathVariable Long id, Authentication authentication) {
+        ShopProject project = shopProjectService.findById(id).orElseThrow();
+        // TODO: check payment status before allowing download
+        File file = codeGenerationService.generateShopCode(project.getId());
+        return ResponseEntity.ok(new FileSystemResource(file));
+    }
+}

--- a/src/main/java/app/mydevbro/backend/controller/ShopProjectController.java
+++ b/src/main/java/app/mydevbro/backend/controller/ShopProjectController.java
@@ -1,0 +1,37 @@
+package app.mydevbro.backend.controller;
+
+import app.mydevbro.backend.entity.ShopProject;
+import app.mydevbro.backend.entity.User;
+import app.mydevbro.backend.service.ShopProjectService;
+import app.mydevbro.backend.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ShopProjectController {
+
+    private final ShopProjectService shopProjectService;
+    private final UserService userService;
+
+    public ShopProjectController(ShopProjectService shopProjectService, UserService userService) {
+        this.shopProjectService = shopProjectService;
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ShopProject> create(Authentication authentication,
+                                              @RequestBody ShopProject project) {
+        User user = userService.findByEmail(authentication.getName()).orElseThrow();
+        return ResponseEntity.ok(shopProjectService.create(user, project));
+    }
+
+    @GetMapping
+    public List<ShopProject> list(Authentication authentication) {
+        User user = userService.findByEmail(authentication.getName()).orElseThrow();
+        return shopProjectService.findByUser(user);
+    }
+}

--- a/src/main/java/app/mydevbro/backend/controller/UserController.java
+++ b/src/main/java/app/mydevbro/backend/controller/UserController.java
@@ -1,0 +1,26 @@
+package app.mydevbro.backend.controller;
+
+import app.mydevbro.backend.entity.User;
+import app.mydevbro.backend.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<User> getCurrentUser(Authentication authentication) {
+        String email = authentication.getName();
+        return userService.findByEmail(email)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/app/mydevbro/backend/entity/Address.java
+++ b/src/main/java/app/mydevbro/backend/entity/Address.java
@@ -1,0 +1,21 @@
+package app.mydevbro.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Address {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String street;
+    private String zip;
+    private String city;
+    private String country;
+}

--- a/src/main/java/app/mydevbro/backend/entity/Payment.java
+++ b/src/main/java/app/mydevbro/backend/entity/Payment.java
@@ -1,0 +1,25 @@
+package app.mydevbro.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String paypalPaymentId;
+    private String status;
+    private Double amount;
+    private String currency;
+
+    @OneToOne
+    @JoinColumn(name = "shop_project_id")
+    private ShopProject shopProject;
+}

--- a/src/main/java/app/mydevbro/backend/entity/Product.java
+++ b/src/main/java/app/mydevbro/backend/entity/Product.java
@@ -1,0 +1,27 @@
+package app.mydevbro.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String description;
+    private BigDecimal price;
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "shop_project_id")
+    private ShopProject shopProject;
+}

--- a/src/main/java/app/mydevbro/backend/entity/ShopProject.java
+++ b/src/main/java/app/mydevbro/backend/entity/ShopProject.java
@@ -1,0 +1,30 @@
+package app.mydevbro.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class ShopProject {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String shopName;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "shopProject", cascade = CascadeType.ALL)
+    private List<Product> products;
+
+    @OneToOne(mappedBy = "shopProject", cascade = CascadeType.ALL)
+    private Payment payment;
+}

--- a/src/main/java/app/mydevbro/backend/entity/User.java
+++ b/src/main/java/app/mydevbro/backend/entity/User.java
@@ -1,0 +1,35 @@
+package app.mydevbro.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstName;
+    private String lastName;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private String password;
+    private LocalDate birthDate;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "address_id")
+    private Address address;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<ShopProject> projects;
+}

--- a/src/main/java/app/mydevbro/backend/repository/AddressRepository.java
+++ b/src/main/java/app/mydevbro/backend/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package app.mydevbro.backend.repository;
+
+import app.mydevbro.backend.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/src/main/java/app/mydevbro/backend/repository/PaymentRepository.java
+++ b/src/main/java/app/mydevbro/backend/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package app.mydevbro.backend.repository;
+
+import app.mydevbro.backend.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/app/mydevbro/backend/repository/ProductRepository.java
+++ b/src/main/java/app/mydevbro/backend/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package app.mydevbro.backend.repository;
+
+import app.mydevbro.backend.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByShopProjectId(Long shopProjectId);
+}

--- a/src/main/java/app/mydevbro/backend/repository/ShopProjectRepository.java
+++ b/src/main/java/app/mydevbro/backend/repository/ShopProjectRepository.java
@@ -1,0 +1,10 @@
+package app.mydevbro.backend.repository;
+
+import app.mydevbro.backend.entity.ShopProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ShopProjectRepository extends JpaRepository<ShopProject, Long> {
+    List<ShopProject> findByUserId(Long userId);
+}

--- a/src/main/java/app/mydevbro/backend/repository/UserRepository.java
+++ b/src/main/java/app/mydevbro/backend/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package app.mydevbro.backend.repository;
+
+import app.mydevbro.backend.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/app/mydevbro/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/app/mydevbro/backend/security/JwtAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package app.mydevbro.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            String email = jwtUtil.validateAndGetSubject(token);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(email, null, null);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/app/mydevbro/backend/security/JwtUtil.java
+++ b/src/main/java/app/mydevbro/backend/security/JwtUtil.java
@@ -1,0 +1,34 @@
+package app.mydevbro.backend.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final long expirationMs = 86400000; // 1 day
+
+    public String generateToken(String subject) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String validateAndGetSubject(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+}

--- a/src/main/java/app/mydevbro/backend/security/SecurityConfig.java
+++ b/src/main/java/app/mydevbro/backend/security/SecurityConfig.java
@@ -1,0 +1,46 @@
+package app.mydevbro.backend.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/app/mydevbro/backend/service/CodeGenerationService.java
+++ b/src/main/java/app/mydevbro/backend/service/CodeGenerationService.java
@@ -1,0 +1,12 @@
+package app.mydevbro.backend.service;
+
+import org.springframework.stereotype.Service;
+import java.io.File;
+
+@Service
+public class CodeGenerationService {
+    public File generateShopCode(Long projectId) {
+        // TODO: implement code generation logic
+        return new File("shop-" + projectId + ".zip");
+    }
+}

--- a/src/main/java/app/mydevbro/backend/service/PaymentService.java
+++ b/src/main/java/app/mydevbro/backend/service/PaymentService.java
@@ -1,0 +1,18 @@
+package app.mydevbro.backend.service;
+
+import app.mydevbro.backend.entity.Payment;
+import app.mydevbro.backend.repository.PaymentRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+
+    public PaymentService(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    public Payment save(Payment payment) {
+        return paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/app/mydevbro/backend/service/ProductService.java
+++ b/src/main/java/app/mydevbro/backend/service/ProductService.java
@@ -1,0 +1,30 @@
+package app.mydevbro.backend.service;
+
+import app.mydevbro.backend.entity.Product;
+import app.mydevbro.backend.entity.ShopProject;
+import app.mydevbro.backend.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public Product addProduct(ShopProject project, Product product) {
+        product.setShopProject(project);
+        return productRepository.save(product);
+    }
+
+    public List<Product> findByProject(Long projectId) {
+        return productRepository.findByShopProjectId(projectId);
+    }
+
+    public void deleteProduct(Long id) {
+        productRepository.deleteById(id);
+    }
+}

--- a/src/main/java/app/mydevbro/backend/service/ShopProjectService.java
+++ b/src/main/java/app/mydevbro/backend/service/ShopProjectService.java
@@ -1,0 +1,35 @@
+package app.mydevbro.backend.service;
+
+import app.mydevbro.backend.entity.ShopProject;
+import app.mydevbro.backend.entity.User;
+import app.mydevbro.backend.repository.ShopProjectRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ShopProjectService {
+    private final ShopProjectRepository shopProjectRepository;
+
+    public ShopProjectService(ShopProjectRepository shopProjectRepository) {
+        this.shopProjectRepository = shopProjectRepository;
+    }
+
+    public ShopProject create(User user, ShopProject project) {
+        project.setUser(user);
+        return shopProjectRepository.save(project);
+    }
+
+    public List<ShopProject> findByUser(User user) {
+        return shopProjectRepository.findByUserId(user.getId());
+    }
+
+    public Optional<ShopProject> findById(Long id) {
+        return shopProjectRepository.findById(id);
+    }
+
+    public void delete(Long id) {
+        shopProjectRepository.deleteById(id);
+    }
+}

--- a/src/main/java/app/mydevbro/backend/service/UserService.java
+++ b/src/main/java/app/mydevbro/backend/service/UserService.java
@@ -1,0 +1,32 @@
+package app.mydevbro.backend.service;
+
+import app.mydevbro.backend.entity.User;
+import app.mydevbro.backend.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User register(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        return userRepository.save(user);
+    }
+
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- set up basic domain entities for users, projects, products, payments and addresses
- add repositories and services for persistence logic
- introduce JWT based security configuration
- scaffold simple controllers for auth, user profile, project management and downloads
- declare dependencies for JWT and PayPal SDK

## Testing
- `./mvnw -q test` *(fails: network access for Maven wrapper is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877d30d744c832587035f7518bfa051